### PR TITLE
Feature/api validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
 
 		<!-- 3rd Party Libraries -->
 		<!-- REST API Doc: Swagger -->

--- a/src/main/java/com/pondit/portfolio/controller/rest/PostRestController.java
+++ b/src/main/java/com/pondit/portfolio/controller/rest/PostRestController.java
@@ -4,10 +4,10 @@ import com.pondit.portfolio.exception.custom.NotFoundException;
 import com.pondit.portfolio.model.domain.Post;
 import com.pondit.portfolio.model.dto.CreatePostRequest;
 import com.pondit.portfolio.model.dto.UpdatePostRequest;
-import com.pondit.portfolio.model.dto.UpdateProjectRequest;
 import com.pondit.portfolio.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -30,13 +30,13 @@ public class PostRestController {
 
     @Operation(summary = "Create a new post")
     @PostMapping
-    public void createPost(CreatePostRequest createPostRequest) {
+    public void createPost(@Valid @RequestBody CreatePostRequest createPostRequest) {
        postService.create(createPostRequest);
     }
 
     @Operation(summary = "Update a post by id")
     @PutMapping("{id}")
-    public void updateProject(@PathVariable Long id, @RequestBody UpdatePostRequest request) throws NotFoundException {
+    public void updateProject(@PathVariable Long id,@Valid @RequestBody UpdatePostRequest request) throws NotFoundException {
         postService.update(id, request);
     }
 

--- a/src/main/java/com/pondit/portfolio/model/dto/CreatePostRequest.java
+++ b/src/main/java/com/pondit/portfolio/model/dto/CreatePostRequest.java
@@ -1,7 +1,19 @@
 package com.pondit.portfolio.model.dto;
 
-public record CreatePostRequest(String title,String content,
-                                 boolean published) {
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
-}
+public record CreatePostRequest(
+        @NotBlank(message = "Title is mandatory")
+        @Size(min = 5, message = "Title must be at least 5 characters long")
+        String title,
+
+        @NotBlank(message = "Content is mandatory")
+        @Size(min = 10, message = "Content must be at least 10 characters long")
+        String content,
+
+        @NotNull(message = "Published status is required")
+        Boolean published
+) {}

--- a/src/main/java/com/pondit/portfolio/model/dto/UpdatePostRequest.java
+++ b/src/main/java/com/pondit/portfolio/model/dto/UpdatePostRequest.java
@@ -1,4 +1,12 @@
 package com.pondit.portfolio.model.dto;
 
-public record UpdatePostRequest(String content, boolean published) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdatePostRequest(
+        @NotBlank(message = "Content is mandatory")
+        @Size(min = 10, message = "Content must be at least 10 characters long")
+        String content,
+        boolean published
+) {
 }


### PR DESCRIPTION
Fixes Issue #32 — Add Validation to Post Creation API
1. Added bean validation to the CreatePostRequest DTO using annotations like @NotBlank and @Size to ensure proper input constraints for title and content.

2. Updated the controller method to use @RequestBody and @Valid so that JSON input is properly deserialized and validated.

3. Ensured that empty or blank inputs are rejected with meaningful error messages.